### PR TITLE
Add matchMedia to bower.json

### DIFF
--- a/blueprints/ember-paper/index.js
+++ b/blueprints/ember-paper/index.js
@@ -9,7 +9,8 @@ module.exports = {
 
   afterInstall: function() {
     var _this = this;
-    return this.addBowerPackagesToProject([{name: 'hammerjs', target:'latest'}]).then(function() {
+    return this.addBowerPackagesToProject([{name: 'hammerjs', target:'latest'}, 
+                                           {name: 'matchMedia', target: '0.2.0'}]).then(function() {
       return _this.addPackagesToProject([{name: 'ember-cli-sass', target: 'latest'}]);
     });
   }


### PR DESCRIPTION
Fixes a missing dependency added by https://github.com/miguelcobain/ember-paper/pull/138.
